### PR TITLE
Support multiple campaign identifiers

### DIFF
--- a/lib/matomo.dart
+++ b/lib/matomo.dart
@@ -262,18 +262,18 @@ class MatomoTracker {
 class Campaign {
   final String? name;
   final String? keyword;
-  final String? gclid;
+  final Map<String, String>? identifiers;
 
   Campaign(
     this.name,
     this.keyword, {
-    this.gclid,
+    this.identifiers,
   });
 
   Campaign.fromUtmParameters(Map<String, dynamic> json)
       : this.name = json['utm_campaign'] ?? (json['utm_medium'] ?? json['utm_source']),
         this.keyword = json['utm_term'],
-        this.gclid = json['gclid'];
+        this.identifiers = json['identifiers'] is Map<String, String> ? json['identifiers'] : null;
 }
 
 class _Session {
@@ -345,9 +345,12 @@ class _Event {
         map['_rck'] = this.tracker.campaign!.keyword;
         entries.addEntries([MapEntry('utm_term', this.tracker.campaign!.keyword!)]);
       }
-      if (this.tracker.campaign!.gclid != null) {
-        map['gclid'] = this.tracker.campaign!.gclid;
-        entries.addEntries([MapEntry('gclid', this.tracker.campaign!.gclid!)]);
+      if (this.tracker.campaign!.identifiers != null) {
+        final identifiers = tracker.campaign!.identifiers;
+        identifiers?.forEach((key, value) {
+          map[key.toLowerCase()] = value;
+          entries.addEntries([MapEntry(key.toLowerCase(), value)]);
+        });
       }
 
       if (url.hasQuery) {

--- a/lib/matomo.dart
+++ b/lib/matomo.dart
@@ -348,8 +348,8 @@ class _Event {
       if (this.tracker.campaign!.identifiers != null) {
         final identifiers = tracker.campaign!.identifiers;
         identifiers?.forEach((key, value) {
-          map[key.toLowerCase()] = value;
-          entries.addEntries([MapEntry(key.toLowerCase(), value)]);
+          map[key] = value;
+          entries.addEntries([MapEntry(key, value)]);
         });
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/matomo_test.dart
+++ b/test/matomo_test.dart
@@ -1,1 +1,26 @@
-void main() {}
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matomo/matomo.dart';
+
+void main() {
+  group('Campaign', () {
+    test('should be able to handle multiple identifiers', () {
+      final utmParameters = <String, dynamic>{
+        'utm_campaign': 'mock_utm_campaign',
+        'utm_term': 'mock_utm_term',
+        'identifiers': <String, String>{
+          'gclid': 'mock_gclid_value',
+          'ob_click_id': 'mock_outbrain_click_id',
+        },
+      };
+
+      final campaign = Campaign.fromUtmParameters(utmParameters);
+      expect(campaign.name, 'mock_utm_campaign');
+      expect(campaign.keyword, 'mock_utm_term');
+      expect(campaign.identifiers, isNotNull);
+      expect(campaign.identifiers?.containsKey('gclid'), isTrue);
+      expect(campaign.identifiers?['gclid'], 'mock_gclid_value');
+      expect(campaign.identifiers?.containsKey('ob_click_id'), isTrue);
+      expect(campaign.identifiers?['ob_click_id'], 'mock_outbrain_click_id');
+    });
+  });
+}


### PR DESCRIPTION
- support multiple campaign identifiers
- extract identifiers as map and send it back to matomo